### PR TITLE
Fix aggregation of file modifications

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nite-owl",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "description": "A debounced EventEmitter that watches for file changes",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nite-owl",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A debounced EventEmitter that watches for file changes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
> event handlers are now passed a list of file paths rather than just a
> single one
>
> previously individual changes were lost if multiple files were modified
> within the respective debounce interval:
>
>     $ touch foo bar
>
> due to the way debouncing was handled before, only one of those changes
> was reported

273e9db4e3a62c1b71edd7f2b89c49e713a377de
