### PR TITLE
Handle errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /node_modules
+/package-lock.json

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ ourselves. We simply use [chokidar](https://github.com/paulmillr/chokidar).
 Using nite-owl basically comes down to this:
 
 ```js
-let watch = require('nite-owl')
+let watch = require("nite-owl");
 
 watch(myFavoriteDirectory)
-    .on('edit', myFavoriteFunction)
-    .on('error', myErrorFunction);
+    .on("edit", myFavoriteFunction)
+    .on("error", myErrorFunction);
 ```
 
 Now, whenever something about the files in `myFavoriteDirectory` changes, the
@@ -32,14 +32,14 @@ case you have to either increase the inotify limits or choose to watch less
 files. An error handler could look like this:
 
 ```js
-watch(myFavoriteDirectory).on('error', (err) => {
-    if(err.code === 'ERR_TOO_MANY_FILES') {
-        console.error('Watching too many files');
-        process.exit(1);
-    } else {
-        throw err;
-    }
-})
+watch(myFavoriteDirectory).on("error", err => {
+	if(err.code === "ERR_TOO_MANY_FILES") {
+		console.error("Watching too many files");
+		process.exit(1);
+	} else {
+		throw err;
+	}
+});
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ let watch = require('nite-owl')
 
 watch(myFavoriteDirectory)
     .on('edit', myFavoriteFunction)
+    .on('error', myErrorFunction);
 ```
 
 Now, whenever something about the files in `myFavoriteDirectory` changes, the
@@ -23,6 +24,23 @@ Now, whenever something about the files in `myFavoriteDirectory` changes, the
 This notification is debounced: You only get notified at most once every 50
 milliseconds. You can adjust that value by providing a second argument to the
 watch function.
+
+The error callback will be called, when watching the files resulted in an
+error. The most common error is the `TooManyFilesError` (it has the code
+`ERR_TOO_MANY_FILES`). It occurs on Linux when you watch too many files. In this
+case you have to either increase the inotify limits or choose to watch less
+files. An error handler could look like this:
+
+```js
+watch(myFavoriteDirectory).on('error', (err) => {
+    if(err.code === 'ERR_TOO_MANY_FILES') {
+        console.error('Watching too many files');
+        process.exit(1);
+    } else {
+        throw err;
+    }
+})
+```
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nite-owl",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A debounced EventEmitter that watches for file changes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
If an error occurs while watching files, we should give the user a chance to react to it. We do this by offering to provide an `error` handler. If an error occurs, and the user is not listening for an error, we will throw the error instead.

There is an error that occurs on Linux systems when you watch too many files. The error is misleading, because it is a ENOSPC. We will translate this error in our own `ERR_TOO_MANY_FILES` error with a corresponding message.