### PR TITLE
Report monitored directories

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,9 +11,14 @@ class TooManyFilesError extends Error {
 	}
 };
 
-module.exports = (rootDirs, delay = 50) => {
+module.exports = (rootDirs, { delay = 50, suppressReporting }) => {
 	if(!rootDirs.pop) {
 		rootDirs = [rootDirs];
+	}
+
+	if(!suppressReporting) {
+		let separator = rootDirs.length === 1 ? " " : "\n… ";
+		console.error("monitoring file system at" + separator + rootDirs.join(separator));
 	}
 
 	let patterns = rootDirs.map(dir => path.resolve(dir, "**"));


### PR DESCRIPTION
> this tends to avoid confusion by confirming the watcher was set up
> properly (or allowing users to recognize configuration errors)

a600a2849c4d0409ba2aca9844d08a6ac8e4e46e

I found myself duplicating this in tests:
https://github.com/faucet-pipeline/faucet-pipeline/blob/f09ddc9674220352b778c132d5b427409c081cd8/index.js#L53
So it seemed sensible to add it to nite-owl instead.

NB:

* obviously this would be a minor-version change
* note that I added "…" as line-continuation indicators - not sure whether that makes sense