### PR TITLE
Add option to shut down watcher

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,14 @@ module.exports = (rootDirs, delay = 50) => {
 		}
 	});
 
-	return emitter;
+	return {
+		on(name, fn) {
+			emitter.on(name, fn);
+		},
+		terminate() {
+			watcher.close();
+		}
+	};
 };
 
 function notifier(delay, callback) {

--- a/package.json
+++ b/package.json
@@ -23,8 +23,7 @@
     "chokidar": "^1.7.0"
   },
   "devDependencies": {
-    "eslint": "^4.4.1",
     "eslint-config-fnd": "^1.2.0",
-    "release-util-fnd": "^1.0.4"
+    "release-util-fnd": "^1.0.7"
   }
 }


### PR DESCRIPTION
>     let watcher = niteOwl(…)
>     …
>     watcher.terminate();
>
> this is primarily useful for tests, as otherwise the watcher being
> persistent will prevent the process from exiting

df89ff82e239145eb8f171172c4c2847fe306c2e