### PR TITLE
Ensure EventEmitter interface is maintained

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,13 +39,13 @@ module.exports = (rootDirs, { delay = 50, suppressReporting } = {}) => {
 		}
 	});
 
-	return {
-		on(name, fn) {
-			emitter.on(name, fn);
-		},
-		terminate() {
+	let wrapper = {
+		terminate: function() {
 			watcher.close();
-		}
+		};
+	};
+	return new Proxy(emitter, {
+		get: (target, prop, receiver) => wrapper[prop] || target[prop];
 	};
 };
 


### PR DESCRIPTION
> this was changed in 983339d8c7c70c83a653da536419027da307601b, which
> limited the API to a couple of known methods - however, thanks to
> `Proxy`, we don't have to accept that unintuitive constraint, allowing
> users to continue to use `#once`, `#removeListener` etc.

d7d4f9cf00b1ff36db8f4074f8488c87a9efd55f

cf. https://github.com/faucet-pipeline/nite-owl/pull/7/files#r158639092

caveat: this particular implementation is currently untested - however, I've confirmed that `Proxy` is supported by Node v6