### PR TITLE
bump chokidar to avoid node 10 upath install error

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/faucet-pipeline/nite-owl#readme",
   "dependencies": {
-    "chokidar": "^2.0.3"
+    "chokidar": "^2.0.4"
   },
   "devDependencies": {
     "eslint-config-fnd": "^1.4.0",


### PR DESCRIPTION
* bumps chokidar to v2.0.4 to avoid node v10 install error (see https://github.com/paulmillr/chokidar/pull/717)

```
▶ node -v
v10.7.0

▶ yarn install
yarn install v1.9.4
[1/4] 🔍  Resolving packages...
[2/4] 🚚  Fetching packages...
[------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------] 0/934(node:54205) [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
error upath@1.0.2: The engine "node" is incompatible with this module. Expected version ">=4 <=9".
error Found incompatible module
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

▶ npm ls upath
my-fancy-project@0.1.0 /Users/mjansing/work/projects/my-fancy-project
└─┬ faucet-pipeline-sass@1.0.0-rc.7
  └─┬ faucet-pipeline-core@1.0.0-rc.12
    └─┬ nite-owl@3.3.1
      └─┬ chokidar@2.0.2
        └── upath@1.0.2

```

With this PR v3.3.2 should be released and nite-owl should be bundled with next faucet-pipeline-core release.