### PR TITLE
Improve backwards compatibility by switching sets to opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nite-owl",
-  "version": "4.0.0",
+  "version": "5.0.0",
   "description": "A debounced EventEmitter that watches for file changes",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
> cf. previous commit (137b4fee06b215aa71d504e740070f389bd55120) - turns
> out downstream projects can't easily upgrade otherwise
>
> in the process, improved error message