### PR TITLE
Fix Windows compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ let chokidar = require("chokidar");
 let EventEmitter = require("events");
 let path = require("path");
 
+let NORMALIZE_PATH = path.sep !== "/"; // typically indicates Windows
+
 module.exports = (rootDirs, { delay = 50, reportSet, suppressReporting } = {}) => {
 	if(!rootDirs.pop) {
 		rootDirs = [rootDirs];
@@ -14,7 +16,12 @@ module.exports = (rootDirs, { delay = 50, reportSet, suppressReporting } = {}) =
 		console.error("monitoring file system at" + separator + rootDirs.join(separator));
 	}
 
-	let patterns = rootDirs.map(dir => path.resolve(dir, "**"));
+	let patterns = rootDirs.map(dir => {
+		let pattern = path.resolve(dir, "**");
+		if(NORMALIZE_PATH) { // chokidar expects POSIX path separators
+			pattern.split(path.sep).join("/");
+		}
+	});
 	let watcher = chokidar.watch(patterns);
 	let emitter = new EventEmitter();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nite-owl",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A debounced EventEmitter that watches for file changes",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   },
   "homepage": "https://github.com/faucet-pipeline/nite-owl#readme",
   "dependencies": {
-    "chokidar": "^2.0.4"
+    "chokidar": "^2.1.2"
   },
   "devDependencies": {
     "eslint-config-fnd": "^1.6.0",


### PR DESCRIPTION
from [chokidar's CHANGELOG](https://github.com/paulmillr/chokidar/blob/master/CHANGELOG.md):

> always use POSIX-style slashes because Windows-style slashes are used as escape sequences

note the inline comment though; naively replacing `\` with `/` might break if a path contains an escaped `\` literal?